### PR TITLE
3Esys: x86_64 Cross-Compiler für ARM64-Hosts

### DIFF
--- a/BsysV2/3Esys/Dockerfile
+++ b/BsysV2/3Esys/Dockerfile
@@ -48,7 +48,11 @@ RUN ARCH="$(dpkg --print-architecture)" && \
 RUN dpkgArch="$(dpkg --print-architecture)"; \
     case "${dpkgArch##*-}" in \
         arm64) \
-            packages="qemu-system-x86" \
+            packages="gcc-x86-64-linux-gnu \
+                      gdb-multiarch \
+                      qemu-system-x86 \
+                      qemu-user-static \
+                      libc6-dev-amd64-cross" \
             ;; \
         amd64) \
             packages="gcc-aarch64-linux-gnu \


### PR DESCRIPTION
## Summary
- x86_64 Cross-Compilation-Tools im ARM64-Case des 3Esys-Dockerfiles ergänzt
- Bisher fehlten `gcc-x86-64-linux-gnu`, `gdb-multiarch`, `qemu-user-static` und `libc6-dev-amd64-cross` — nur `qemu-system-x86` war installiert
- ARM64-Case ist jetzt symmetrisch zum bestehenden amd64→arm64 Cross-Compile-Setup

## Test plan
- [ ] Image auf ARM64-Runner bauen (`docker build BsysV2/3Esys/`)
- [ ] `x86_64-linux-gnu-gcc --version` im Container prüfen
- [ ] HW1 Kernel Cross-Compile testen (`make ARCH=x86_64 CROSS_COMPILE=x86_64-linux-gnu-`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)