### PR TITLE
Update docs to use ghcr.io instead of DockerHub

### DIFF
--- a/docs/DockerExperts.md
+++ b/docs/DockerExperts.md
@@ -2,22 +2,20 @@
 
 Install [Ubuntu](https://ubuntu.com/tutorials/install-ubuntu-desktop#1-overview) with [Docker](https://docs.docker.com/engine/install/ubuntu/) and build the Docker-Image.
 
-### Intel/amd64 Architecture
+### Container starten
 
-Local building is not necessary. The image can be pulled from DockerHub.
+Local building is not necessary. The image can be pulled from ghcr.io (Multi-Arch, works on amd64 and arm64):
 
-Base:
+BSYS:
 
 ```bash
-docker run -d -p 127.0.0.1:40405:22 --name=pocketlab systemlabor/bsys:pocketlabbase
+docker run -d -p 127.0.0.1:40405:22 --name=bsyslab ghcr.io/htwg-syslab/container/bsyslab:latest
 ```
 
-### Apple arm64 Architecture
-
-Base:
+ESYS:
 
 ```bash
-docker run -d -p 127.0.0.1:40405:22 --name=pocketlab systemlabor/bsys:pocketlabbase-ARM64
+docker run -d -p 127.0.0.1:40407:22 -v esyslab-home:/home/pocketlab --name=esyslab ghcr.io/htwg-syslab/container/esyslab:latest
 ```
 
 ## login (shown with Intel/amd64 Architecture)

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,6 @@
 
 Mit Pocketlab können Entwickler und Administratoren eine **konsistente Umgebung** schaffen, unabhängig davon, ob die Container **lokal**, in der **Cloud** oder auf anderen Systemen betrieben werden. Dies macht Pocketlab ideal für die **Entwicklung**, das **Testen** und den produktiven **Einsatz** von Anwendungen in vielfältigen Umgebungen.
 
-## Link zum Dockerhub
+## Container Images
 
-Eine Sammlung von vorgefertigten **Pocketlab-Containern** finden Sie auf [DockerHub](https://hub.docker.com/u/systemlabor). Diese **Images** können direkt heruntergeladen und in Ihrer Umgebung verwendet werden.
+Die vorgefertigten **Pocketlab-Container** stehen als Multi-Arch Images (amd64/arm64) auf der [GitHub Container Registry](https://github.com/orgs/htwg-syslab/packages) bereit und können direkt heruntergeladen werden.


### PR DESCRIPTION
## Summary
- Replace old DockerHub link (`hub.docker.com/u/systemlabor`) in `docs/README.md` with GitHub Container Registry
- Update `docs/DockerExperts.md`: replace `systemlabor/bsys` Docker Hub images with `ghcr.io/htwg-syslab/container/bsyslab` and `esyslab` (Multi-Arch)
- Aligns documentation with image renaming from PR #74

## Test plan
- [ ] Verify `docker run` commands in docs use correct ghcr.io image names
- [ ] Verify README links point to GitHub Container Registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)