### PR TITLE
Fix readlink + pyenv-Init Volume-robust

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -21,7 +21,14 @@ RUN apt-get update && \
 
 # Ubuntu 26.04: uutils-coreutils readlink ist inkompatibel mit vielen Tools
 # (pyenv, etc.) — GNU readlink als Default setzen
-RUN ln -sf /usr/bin/gnureadlink /usr/local/bin/readlink
+RUN if [ -x /usr/bin/gnureadlink ]; then \
+        ln -sf /usr/bin/gnureadlink /usr/local/bin/readlink; \
+    elif [ -x /usr/bin/readlink ]; then \
+        ln -sf /usr/bin/readlink /usr/local/bin/readlink; \
+    else \
+        echo "ERROR: Neither /usr/bin/gnureadlink nor /usr/bin/readlink found" >&2; \
+        exit 1; \
+    fi
 
 # Configure locale
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y tzdata

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -19,6 +19,10 @@ RUN apt-get update && \
     sudo \
     dos2unix
 
+# Ubuntu 26.04: uutils-coreutils readlink ist inkompatibel mit vielen Tools
+# (pyenv, etc.) — GNU readlink als Default setzen
+RUN ln -sf /usr/bin/gnureadlink /usr/local/bin/readlink
+
 # Configure locale
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y tzdata
 

--- a/Dockerfile.pythonlab
+++ b/Dockerfile.pythonlab
@@ -9,13 +9,10 @@ RUN apt-get update && \
 # Install pyenv
 RUN curl https://pyenv.run | su - pocketlab -c 'bash'
 
-# Update bash config with pyenv paths
-RUN echo 'export PYENV_ROOT="$HOME/.pyenv"' >> /home/pocketlab/.bashrc; \
-    echo '[[ -d $PYENV_ROOT/bin ]] && export PATH="$PYENV_ROOT/bin:$PATH"' >> /home/pocketlab/.bashrc; \
-    echo 'eval "$(pyenv init - bash)"' >> /home/pocketlab/.bashrc; \
-    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> /home/pocketlab/.profile; \
-    echo '[[ -d $PYENV_ROOT/bin ]] && export PATH="$PYENV_ROOT/bin:$PATH"' >> /home/pocketlab/.profile; \
-    echo 'eval "$(pyenv init - bash)"' >> /home/pocketlab/.profile
+# pyenv-Init als Drop-in unter /etc/profile.d/ (unabhängig vom Home-Volume)
+RUN echo 'export PYENV_ROOT="$HOME/.pyenv"' > /etc/profile.d/pyenv.sh; \
+    echo 'if [ -d "$PYENV_ROOT/bin" ]; then export PATH="$PYENV_ROOT/bin:$PATH"; eval "$(pyenv init - bash)"; fi' >> /etc/profile.d/pyenv.sh; \
+    chmod +x /etc/profile.d/pyenv.sh
 
 # Clone the OSTEP Homework repository
 RUN git clone https://github.com/remzi-arpacidusseau/ostep-homework /home/pocketlab/ostep-homework

--- a/Dockerfile.pythonlab
+++ b/Dockerfile.pythonlab
@@ -11,7 +11,7 @@ RUN curl https://pyenv.run | su - pocketlab -c 'bash'
 
 # pyenv-Init als Drop-in unter /etc/profile.d/ (unabhängig vom Home-Volume)
 RUN echo 'export PYENV_ROOT="$HOME/.pyenv"' > /etc/profile.d/pyenv.sh; \
-    echo 'if [ -d "$PYENV_ROOT/bin" ]; then export PATH="$PYENV_ROOT/bin:$PATH"; eval "$(pyenv init - bash)"; fi' >> /etc/profile.d/pyenv.sh; \
+    echo 'if [ -x "$PYENV_ROOT/bin/pyenv" ]; then export PATH="$PYENV_ROOT/bin:$PATH"; eval "$(pyenv init - bash)"; fi' >> /etc/profile.d/pyenv.sh; \
     chmod +x /etc/profile.d/pyenv.sh
 
 # Clone the OSTEP Homework repository

--- a/Dockerfile.pythonlab
+++ b/Dockerfile.pythonlab
@@ -12,7 +12,8 @@ RUN curl https://pyenv.run | su - pocketlab -c 'bash'
 # pyenv-Init als Drop-in unter /etc/profile.d/ (unabhängig vom Home-Volume)
 RUN echo 'export PYENV_ROOT="$HOME/.pyenv"' > /etc/profile.d/pyenv.sh; \
     echo 'if [ -x "$PYENV_ROOT/bin/pyenv" ]; then export PATH="$PYENV_ROOT/bin:$PATH"; eval "$(pyenv init - bash)"; fi' >> /etc/profile.d/pyenv.sh; \
-    chmod +x /etc/profile.d/pyenv.sh
+    chmod +x /etc/profile.d/pyenv.sh; \
+    echo 'if [ -f /etc/profile.d/pyenv.sh ]; then . /etc/profile.d/pyenv.sh; fi' >> /etc/bash.bashrc
 
 # Clone the OSTEP Homework repository
 RUN git clone https://github.com/remzi-arpacidusseau/ostep-homework /home/pocketlab/ostep-homework

--- a/Dockerfile.pythonlab
+++ b/Dockerfile.pythonlab
@@ -11,9 +11,9 @@ RUN curl https://pyenv.run | su - pocketlab -c 'bash'
 
 # pyenv-Init als Drop-in unter /etc/profile.d/ (unabhängig vom Home-Volume)
 RUN echo 'export PYENV_ROOT="$HOME/.pyenv"' > /etc/profile.d/pyenv.sh; \
-    echo 'if [ -x "$PYENV_ROOT/bin/pyenv" ]; then export PATH="$PYENV_ROOT/bin:$PATH"; eval "$(pyenv init - bash)"; fi' >> /etc/profile.d/pyenv.sh; \
+    echo 'if [ -z "${PYENV_INIT_DONE:-}" ] && [ -x "$PYENV_ROOT/bin/pyenv" ]; then export PATH="$PYENV_ROOT/bin:$PATH"; eval "$(pyenv init - bash)"; export PYENV_INIT_DONE=1; fi' >> /etc/profile.d/pyenv.sh; \
     chmod +x /etc/profile.d/pyenv.sh; \
-    echo 'if [ -f /etc/profile.d/pyenv.sh ]; then . /etc/profile.d/pyenv.sh; fi' >> /etc/bash.bashrc
+    echo 'if [ -z "${PYENV_INIT_DONE:-}" ] && [ -f /etc/profile.d/pyenv.sh ]; then . /etc/profile.d/pyenv.sh; fi' >> /etc/bash.bashrc
 
 # Clone the OSTEP Homework repository
 RUN git clone https://github.com/remzi-arpacidusseau/ostep-homework /home/pocketlab/ostep-homework


### PR DESCRIPTION
## Summary

- **Fix (#76):** GNU `readlink` als Default statt uutils-coreutils in `Dockerfile.base` — behebt `readlink: Invalid argument`-Fehler bei pyenv und anderen Tools auf Ubuntu 26.04
- **Enhancement (#78):** pyenv-Init von `~/.bashrc`/`~/.profile` nach `/etc/profile.d/pyenv.sh` verschoben — robust bei persistenten Home-Volumes, mit Guard gegen fehlende pyenv-Installation

## Test plan

- [x] `pythonlab:test` mit pyenv: Login ohne readlink-Fehler, `pyenv --version` funktioniert
- [x] `pythonlab:test` mit leerem Home-Volume: Login ohne Fehler

Closes #76, closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)