### PR TITLE
Add OCI labels to bsyslab and esyslab Dockerfiles

### DIFF
--- a/Dockerfile.bsyslab
+++ b/Dockerfile.bsyslab
@@ -1,5 +1,8 @@
 FROM ghcr.io/htwg-syslab/container/pythonlab:latest
 
+LABEL org.opencontainers.image.source="https://github.com/htwg-syslab/container"
+LABEL org.opencontainers.image.description="BSYS Lab Container Image"
+
 # C Lab Programming Packages
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \

--- a/Dockerfile.esyslab
+++ b/Dockerfile.esyslab
@@ -1,5 +1,8 @@
 FROM ghcr.io/htwg-syslab/container/base:latest
 
+LABEL org.opencontainers.image.source="https://github.com/htwg-syslab/container"
+LABEL org.opencontainers.image.description="ESYS Lab Container Image"
+
 # Install ESYS Lab packages
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \


### PR DESCRIPTION
## Summary\n- Add `org.opencontainers.image.source` and `org.opencontainers.image.description` labels to `Dockerfile.bsyslab` and `Dockerfile.esyslab`\n- These labels allow GitHub to automatically link the container packages to this repository, making them visible under \"Packages\" on the repo page\n\n## Test plan\n- [ ] Verify workflows trigger and images build successfully\n- [ ] After build, check that bsyslab and esyslab packages appear on the GitHub repo page under \"Packages\"\n\nhttps://claude.ai/code/session_01P95xtAfi9MBvPhqsqBhw4d