### PR TITLE
Demo-Pakete ergänzt: strace, kmod, device-tree-compiler

### DIFF
--- a/Dockerfile.esyslab
+++ b/Dockerfile.esyslab
@@ -7,7 +7,7 @@ RUN apt-get update && \
         libc6-dev gettext indent bats \
         netcat-openbsd net-tools iputils-ping traceroute bmon \
         lsof psmisc xz-utils unzip gnupg2 \
-        uml-utilities \
+        uml-utilities strace kmod device-tree-compiler \
         libssl-dev libelf-dev \
         flex bison \
         libncurses-dev libcurses-ocaml-dev zlib1g \


### PR DESCRIPTION
## Summary
- strace, kmod und device-tree-compiler zum esyslab-Image hinzugefügt
- Benötigt für Live-Demos in der linuxkernel2-Vorlesung (Syscall-Tracing, Kernel-Module, Device Tree)

## Test plan
- [ ] Image neu bauen und prüfen, dass die Pakete installiert sind

🤖 Generated with [Claude Code](https://claude.com/claude-code)