### PR TITLE
esyslab: Pakete für alle HW1-7 ergänzt

### DIFF
--- a/Dockerfile.esyslab
+++ b/Dockerfile.esyslab
@@ -11,7 +11,18 @@ RUN apt-get update && \
         libssl-dev libelf-dev \
         flex bison \
         libncurses-dev libcurses-ocaml-dev zlib1g \
-        lsb-release libnotify4 bc expect cpio rsync
+        lsb-release libnotify4 bc expect cpio rsync \
+        # --- Buildroot-Stabilität (HW3+): gawk vermeidet mawk-printf-Stolperer,
+        # pyelftools wird vom Linux-Kernel >=5.x bei Modul-/vmlinux-Verarbeitung gebraucht ---
+        gawk python3-pyelftools \
+        # --- FAT-Tools für SD-Karten + RPi-Boot-Partition (HW3-RPi, HW4) ---
+        dosfstools mtools \
+        # --- Bootloader-Tooling: mkimage (uImage), RPi-Boot-Helfer ---
+        u-boot-tools \
+        # --- TFTP-Server fuer HW3 RPi-Netzwerkboot (manuell starten) ---
+        tftpd-hpa \
+        # --- Realtime-Messungen + Tracing (HW7) ---
+        rt-tests stress-ng trace-cmd kernelshark
 
 # Set clang as gcc
 RUN echo "alias gcc='clang'" >> /etc/bash.bashrc


### PR DESCRIPTION
## Summary

Erweitert `Dockerfile.esyslab` um Pakete, die für den vollen Semesterbogen (HW1 Kernel bis HW7 Realtime) gebraucht werden. Vermeidet `apt install` zur Laufzeit der Studi-CI.

## Was dazu kommt

| Paket | Wofür | Größe |
|---|---|---|
| `gawk` | Buildroot/Kernel-Skript-Stabilität (mawk-Stolperer) | klein |
| `python3-pyelftools` | Linux-Kernel ≥5.x Modul-/vmlinux-Tools | klein |
| `dosfstools`, `mtools` | FAT-Filesysteme (SD-Karte, RPi-Boot — HW3, HW4) | klein |
| `u-boot-tools` | `mkimage`, uImage-Generierung | klein |
| `tftpd-hpa` | optionaler TFTP-Server für RPi-Netzboot (manuell starten) | klein |
| `rt-tests`, `stress-ng` | cyclictest + Lasttests (HW7 Realtime) | klein |
| `trace-cmd`, `kernelshark` | Kernel-Tracing (HW7) | ~150 MB (Qt-Deps) |

Image wächst um ~200-250 MB (vorwiegend kernelshark/Qt). Falls das stört, wäre kernelshark der erste Streich-Kandidat.

## Test plan

- [ ] CI baut X64- und ARM64-Image grün
- [ ] `:latest`-Manifest auf ghcr.io aktualisiert sich
- [ ] Lokal `docker pull ghcr.io/htwg-syslab/container/esyslab:latest && docker run --rm ... which gawk mkimage cyclictest mkfs.vfat` liefert alles