### PR TITLE
esyslab: lz4 wieder hinzufügen (rootfs-Demo)

### DIFF
--- a/Dockerfile.esyslab
+++ b/Dockerfile.esyslab
@@ -22,7 +22,9 @@ RUN apt-get update && \
         # --- TFTP-Server fuer HW3 RPi-Netzwerkboot (manuell starten) ---
         tftpd-hpa \
         # --- Realtime-Messungen + Tracing (HW7) ---
-        rt-tests stress-ng trace-cmd kernelshark
+        rt-tests stress-ng trace-cmd kernelshark \
+        # --- lz4 für rootfs-Demo Kompressionsvergleich (HW1/HW2) ---
+        lz4
 
 # Set clang as gcc
 RUN echo "alias gcc='clang'" >> /etc/bash.bashrc


### PR DESCRIPTION
## Summary

Setzt den Revert aus #?? (`525f697`) zurück. `lz4` wird in der rootfs-Demo (HW1/HW2) für den Kompressionsvergleich gebraucht. Auf esyslab läuft es bereits manuell nachinstalliert.

Paket ist winzig (~150 KB).

## Test plan

- [ ] CI baut grün
- [ ] `docker run --rm ghcr.io/htwg-syslab/container/esyslab:latest which lz4` liefert `/usr/bin/lz4`