### PR TITLE
esyslab: Buildroot host-side dev-Header ergänzt

### DIFF
--- a/Dockerfile.esyslab
+++ b/Dockerfile.esyslab
@@ -24,7 +24,11 @@ RUN apt-get update && \
         # --- Realtime-Messungen + Tracing (HW7) ---
         rt-tests stress-ng trace-cmd kernelshark \
         # --- lz4 für rootfs-Demo Kompressionsvergleich (HW1/HW2) ---
-        lz4
+        lz4 \
+        # --- Buildroot host-side dev-Header (sonst scheitern host-mkpasswd,
+        # host-fakeroot, host-libpython etc. mit "*.h: No such file or directory") ---
+        libxcrypt-dev zlib1g-dev libacl1-dev \
+        libffi-dev libsqlite3-dev libreadline-dev libbz2-dev
 
 # Set clang as gcc
 RUN echo "alias gcc='clang'" >> /etc/bash.bashrc


### PR DESCRIPTION
## Summary

Folge-Fix zu #85: auf grp0 PR #7 ist `host-mkpasswd` während des Buildroot-Builds gefailt mit:

\`\`\`
fatal error: crypt.h: No such file or directory
\`\`\`

Ursache: \`libc6-dev\` liefert die runtime \`libcrypt.so.1\`, aber der Header \`crypt.h\` wandert in Ubuntu 22.04+ in das eigene Paket \`libxcrypt-dev\`.

## Was dazu kommt

Defensiv mehrere oft-übersehene Buildroot host-side dev-Header:

| Paket | Wofür |
|---|---|
| \`libxcrypt-dev\` | crypt.h für host-mkpasswd |
| \`zlib1g-dev\` | zlib-Header (host-Tools, Python) |
| \`libacl1-dev\` | ACL-Header (host-fakeroot, host-makedevs) |
| \`libffi-dev\` | Python-host (ctypes, cffi) |
| \`libsqlite3-dev\` | Python-host (sqlite3-Modul) |
| \`libreadline-dev\` | Python-host (readline) |
| \`libbz2-dev\` | bz2-Header (host-Python, Buildroot-Tools) |

Image wächst ~30 MB.

## Test plan

- [ ] CI baut grün
- [ ] grp0 PR #7 re-trigger → host-mkpasswd-Step durch