### PR TITLE
fix: libxcrypt-dev → libcrypt-dev (korrekter Paketname)

### DIFF
--- a/Dockerfile.esyslab
+++ b/Dockerfile.esyslab
@@ -27,7 +27,7 @@ RUN apt-get update && \
         lz4 \
         # --- Buildroot host-side dev-Header (sonst scheitern host-mkpasswd,
         # host-fakeroot, host-libpython etc. mit "*.h: No such file or directory") ---
-        libxcrypt-dev zlib1g-dev libacl1-dev \
+        libcrypt-dev zlib1g-dev libacl1-dev \
         libffi-dev libsqlite3-dev libreadline-dev libbz2-dev
 
 # Set clang as gcc


### PR DESCRIPTION
## Summary

PR #87 hat `libxcrypt-dev` als Paketnamen verwendet — das gibt es im Ubuntu-Repo nicht (weder 22.04 noch 26.04). Korrekt heißt das Paket **`libcrypt-dev`** (ohne „x"). Selbe Funktionalität (liefert `/usr/include/crypt.h` für `host-mkpasswd`).

## Beweis

Image-Build von #87 ist tatsächlich gescheitert mit `E: Unable to locate package libxcrypt-dev`, sowohl auf X64 als auch ARM64. Dass es als „success" gelistet wurde, liegt an `continue-on-error: true` im docker-build-Job — sollte in einem Folge-PR korrigiert werden, sonst täuscht der Workflow weiterhin grüne Builds vor.

## Test plan

- [ ] CI baut grün (Image-Build sollte diesmal ≥3 min dauern, nicht ~50s)
- [ ] grp0 PR #7 re-trigger → host-mkpasswd-Step durch