### PR TITLE
esyslab: defensive Buildroot-relevante Pakete

### DIFF
--- a/Dockerfile.esyslab
+++ b/Dockerfile.esyslab
@@ -28,7 +28,13 @@ RUN apt-get update && \
         # --- Buildroot host-side dev-Header (sonst scheitern host-mkpasswd,
         # host-fakeroot, host-libpython etc. mit "*.h: No such file or directory") ---
         libcrypt-dev zlib1g-dev libacl1-dev \
-        libffi-dev libsqlite3-dev libreadline-dev libbz2-dev
+        libffi-dev libsqlite3-dev libreadline-dev libbz2-dev \
+        # --- Defensive Ergänzungen (auf esyslab installiert, im Container fehlend) ---
+        # liblzma-dev/libzstd-dev: Kernel-XZ/zstd-Kompression + diverse host-Pakete
+        # libxml2-dev: manche host-Tools mit XML-Verarbeitung
+        # musl-tools: für HW3-Variante mit musl-libc statt glibc (Embedded-Trimm)
+        # qemu-utils: qemu-img u.a. für SD-Karten-Tooling (HW4)
+        liblzma-dev libzstd-dev libxml2-dev musl-tools qemu-utils
 
 # Set clang as gcc
 RUN echo "alias gcc='clang'" >> /etc/bash.bashrc


### PR DESCRIPTION
## Summary

Ergänzt fünf Pakete, die auf dem laufenden esyslab-Container installiert sind (und dort funktionieren — die HW3-Musterlösung ist durchgelaufen) aber im Container-Image bisher fehlen.

## Was dazu kommt

| Paket | Wofür |
|---|---|
| `liblzma-dev` | Kernel-XZ-Kompression + diverse host-Pakete |
| `libzstd-dev` | Kernel-/initramfs-zstd-Kompression (oft default) |
| `libxml2-dev` | host-Tools mit XML-Verarbeitung |
| `musl-tools` | für geplante HW3-Variante mit musl-libc (siehe `lab/solutions/hw3/todo.md`) |
| `qemu-utils` | `qemu-img` für SD-Karten-Tooling (HW4) |

Image wächst ~30-40 MB.

## Methodik

Vergleich `dpkg -l` auf esyslab vs. `Dockerfile.{base,esyslab}` Paketliste, gefiltert auf `*-dev`/`*-tools`/`*-utils`. Was dort installiert ist, aber nicht im Image deklariert, ist Kandidat für Nach-Installation oder hier für vorsorgliche Aufnahme.

## Test plan

- [ ] CI baut grün (echter Build, nicht 50s-Skip)
- [ ] grp0 PR #7 läuft durch