### PR TITLE
esyslab.yml: continue-on-error raus (Pseudo-Successes vermeiden)

### DIFF
--- a/.github/workflows/esyslab.yml
+++ b/.github/workflows/esyslab.yml
@@ -24,8 +24,7 @@ jobs:
     strategy:
       matrix:
         runner: [ubuntu-latest, ubuntu-24.04-arm]
-
-    continue-on-error: true
+      fail-fast: false
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

`continue-on-error: true` hat dafür gesorgt, dass gefailte Builds als „success" gelistet wurden — Fall PR #87 hat mit `Unable to locate package libxcrypt-dev` gefailt und trotzdem grün im Workflow-Status erschienen. Wir hatten keine Möglichkeit, das ohne Log-Lesen zu erkennen.

## Was sich ändert

```diff
-    continue-on-error: true
+      fail-fast: false
```

- **Vorher:** Jeder gefailte Build wurde silently ignoriert, Workflow-Status immer success
- **Nachher:** Echte Build-Fehler werden sichtbar (Job rot, Workflow rot). Bei Multi-Arch-Matrix bleibt erhalten, dass bei ARM64-Fail trotzdem X64 zu Ende läuft (`fail-fast: false`)

## Test plan

- [ ] CI baut grün → Workflow-Status korrekt grün
- [ ] Bei künftigem Paket-Fehler: Workflow rot statt grün → wir merken's sofort