### PR TITLE
esyslab: GNU time + Bootlin aarch64-musl Cross-Toolchain

### DIFF
--- a/Dockerfile.esyslab
+++ b/Dockerfile.esyslab
@@ -3,7 +3,7 @@ FROM ghcr.io/htwg-syslab/container/base:latest
 # Install ESYS Lab packages
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
-        build-essential make gcc clang cmake valgrind \
+        build-essential make gcc clang cmake valgrind time \
         libc6-dev gettext indent bats \
         netcat-openbsd net-tools iputils-ping traceroute bmon \
         lsof psmisc xz-utils unzip gnupg2 \
@@ -71,3 +71,17 @@ RUN dpkgArch="$(dpkg --print-architecture)"; \
             ;; \
     esac; \
     apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y $packages
+
+# --- Bootlin aarch64-musl Cross-Toolchain (HW3 External-Toolchain-Variante) ---
+# Erlaubt Buildroot, eigene Toolchain-Stages zu überspringen → CI-Build von
+# ~30-45 min auf ~5-10 min. Phase-0-Test (lab/solutions/hw3/external-toolchain-plan.md)
+# zeigt 4m54s im x86_64-Container. URL pinned auf Bootlin-Stable, sha256 verifiziert.
+ARG BOOTLIN_AARCH64_MUSL_VERSION=2024.02-1
+ARG BOOTLIN_AARCH64_MUSL_SHA256=aaa1a5c9212067de3618afbb8f3de4047d99fa1d23e5bc1452bab7fd3744df2e
+RUN cd /opt && \
+    wget -q "https://toolchains.bootlin.com/downloads/releases/toolchains/aarch64/tarballs/aarch64--musl--stable-${BOOTLIN_AARCH64_MUSL_VERSION}.tar.bz2" -O bootlin.tar.bz2 && \
+    echo "${BOOTLIN_AARCH64_MUSL_SHA256}  bootlin.tar.bz2" | sha256sum -c - && \
+    mkdir -p cross && \
+    tar xjf bootlin.tar.bz2 -C cross && \
+    rm bootlin.tar.bz2
+ENV BOOTLIN_AARCH64_MUSL_PATH=/opt/cross/aarch64--musl--stable-2024.02-1

--- a/Dockerfile.esyslab
+++ b/Dockerfile.esyslab
@@ -52,6 +52,7 @@ RUN dpkgArch="$(dpkg --print-architecture)"; \
     case "${dpkgArch##*-}" in \
         arm64) \
             packages="gcc-x86-64-linux-gnu \
+                      g++-x86-64-linux-gnu \
                       gdb-multiarch \
                       qemu-system-x86 \
                       qemu-system-arm \
@@ -60,6 +61,7 @@ RUN dpkgArch="$(dpkg --print-architecture)"; \
             ;; \
         amd64) \
             packages="gcc-aarch64-linux-gnu \
+                      g++-aarch64-linux-gnu \
                       gdb-multiarch \
                       qemu-system-x86 \
                       qemu-system-arm \
@@ -76,12 +78,19 @@ RUN dpkgArch="$(dpkg --print-architecture)"; \
 # Erlaubt Buildroot, eigene Toolchain-Stages zu überspringen → CI-Build von
 # ~30-45 min auf ~5-10 min. Phase-0-Test (lab/solutions/hw3/external-toolchain-plan.md)
 # zeigt 4m54s im x86_64-Container. URL pinned auf Bootlin-Stable, sha256 verifiziert.
+# Nur auf amd64: Bootlin-Binaries sind x86_64-Host-→-aarch64-Target; auf arm64-Host
+# nicht ausführbar (außer über qemu-user) und wegen native-aarch64-gcc auch unnötig.
 ARG BOOTLIN_AARCH64_MUSL_VERSION=2024.02-1
 ARG BOOTLIN_AARCH64_MUSL_SHA256=aaa1a5c9212067de3618afbb8f3de4047d99fa1d23e5bc1452bab7fd3744df2e
-RUN cd /opt && \
-    wget -q "https://toolchains.bootlin.com/downloads/releases/toolchains/aarch64/tarballs/aarch64--musl--stable-${BOOTLIN_AARCH64_MUSL_VERSION}.tar.bz2" -O bootlin.tar.bz2 && \
-    echo "${BOOTLIN_AARCH64_MUSL_SHA256}  bootlin.tar.bz2" | sha256sum -c - && \
-    mkdir -p cross && \
-    tar xjf bootlin.tar.bz2 -C cross && \
-    rm bootlin.tar.bz2
+RUN dpkgArch="$(dpkg --print-architecture)"; \
+    if [ "$dpkgArch" = "amd64" ]; then \
+        cd /opt && \
+        wget -q "https://toolchains.bootlin.com/downloads/releases/toolchains/aarch64/tarballs/aarch64--musl--stable-${BOOTLIN_AARCH64_MUSL_VERSION}.tar.bz2" -O bootlin.tar.bz2 && \
+        echo "${BOOTLIN_AARCH64_MUSL_SHA256}  bootlin.tar.bz2" | sha256sum -c - && \
+        mkdir -p cross && \
+        tar xjf bootlin.tar.bz2 -C cross && \
+        rm bootlin.tar.bz2; \
+    else \
+        echo "Skipping Bootlin aarch64-musl toolchain on ${dpkgArch} (x86_64-host binaries, arm64 hat nativen aarch64-gcc)"; \
+    fi
 ENV BOOTLIN_AARCH64_MUSL_PATH=/opt/cross/aarch64--musl--stable-2024.02-1


### PR DESCRIPTION
## Summary
- **`time`** zur Paketliste — liefert `/usr/bin/time` (GNU time, `-v` für Wallclock + Maximum-RSS + Stats). Bash-Builtin reicht nicht.
- **Bootlin aarch64-musl stable 2024.02-1** unter `/opt/cross/aarch64--musl--stable-2024.02-1` baked-in. Erlaubt Buildroot, External Toolchain (`BR2_TOOLCHAIN_EXTERNAL=y`) zu nutzen statt kompletter Toolchain-Eigenbau pro CI-Lauf.

## Hintergrund
Phase 1 des External-Toolchain-Umbaus für die HW3-CI. Phase-0-Test (lokaler `esys:local`-Container, dokumentiert in `lab/solutions/hw3/external-toolchain-plan.md` im Parent-Workspace) zeigt: Build sinkt von ~30-45 min (Internal Toolchain) auf **4m 54s** (External Toolchain), QEMU `aarch64-virt` boot grün (dropbear sshd OK, udhcpc lease, sysinfo).

## Sicherheit
SHA256 (`aaa1a5c9...3744df2e`) gegen den Tarball verifiziert, schützt vor Mirror-Kompromittierung. URL gepinnt auf Bootlin-Stable.

## Image-Größe
Toolchain entpackt ~480 MB (Tarball wird im selben RUN gelöscht, kein Layer-Bloat). Trade-off: deutlich gewachsenes Image gegen ~6-9× schnellere CI-Builds.

## Folge-Schritt (separater PR im Parent)
CI-Workflow `lab/classroom-template/.github/workflows/hw3.yml` von `runs-on: [self-hosted, pi]` auf `runs-on: ubuntu-latest` + `container: ghcr.io/htwg-syslab/container/esyslab:latest` umstellen. M5-Hardware-Tests bleiben self-hosted Pi.

## Test plan
- [ ] CI baut x86_64-Image grün
- [ ] CI baut arm64-Image grün
- [ ] Manifest-Merge nach `:latest` grün
- [ ] Smoketest nach Merge: `docker run --rm ghcr.io/htwg-syslab/container/esyslab:latest /opt/cross/aarch64--musl--stable-2024.02-1/bin/aarch64-buildroot-linux-musl-gcc --version`

🤖 Generated with [Claude Code](https://claude.com/claude-code)