### PR TITLE
esyslab: HW3-Readiness — BOOTLIN-Env in SSH-Login + Buildroot-Maintainer-Key

### DIFF
--- a/Dockerfile.esyslab
+++ b/Dockerfile.esyslab
@@ -94,3 +94,7 @@ RUN dpkgArch="$(dpkg --print-architecture)"; \
         echo "Skipping Bootlin aarch64-musl toolchain on ${dpkgArch} (x86_64-host binaries, arm64 hat nativen aarch64-gcc)"; \
     fi
 ENV BOOTLIN_AARCH64_MUSL_PATH=/opt/cross/aarch64--musl--stable-2024.02-1
+# SSH-Login-Shells lesen /etc/environment via PAM; Docker-ENV propagiert nur
+# an PID 1 (docker exec), nicht an sshd-Kinder. Damit HW3 §4.2 ("umgebungsabhängige
+# Pfade robust behandeln") die Env-Var nutzen kann, hier zusätzlich in /etc/environment.
+RUN echo "BOOTLIN_AARCH64_MUSL_PATH=/opt/cross/aarch64--musl--stable-${BOOTLIN_AARCH64_MUSL_VERSION}" >> /etc/environment

--- a/Dockerfile.esyslab
+++ b/Dockerfile.esyslab
@@ -98,3 +98,13 @@ ENV BOOTLIN_AARCH64_MUSL_PATH=/opt/cross/aarch64--musl--stable-2024.02-1
 # an PID 1 (docker exec), nicht an sshd-Kinder. Damit HW3 §4.2 ("umgebungsabhängige
 # Pfade robust behandeln") die Env-Var nutzen kann, hier zusätzlich in /etc/environment.
 RUN echo "BOOTLIN_AARCH64_MUSL_PATH=/opt/cross/aarch64--musl--stable-${BOOTLIN_AARCH64_MUSL_VERSION}" >> /etc/environment
+
+# --- Buildroot-Maintainer-Key systemweit importieren (HW3 §1.1 / §4.2) ---
+# Buildroot-Tarballs sind GPG-signiert (Maintainer: Thomas Petazzoni). Bei
+# non-interaktivem Skript-Aufruf (CI-Runner, frisch provisionierter Container)
+# fehlt der Key im Root-Keyring — `gpg --verify` scheitert. Der hw3.sh-seitige
+# `--recv-keys`-Fallback deckt fremde Umgebungen (eigener Laptop, pocketlab-User)
+# ab; dieser Layer nimmt den Keyserver-Roundtrip aus dem CI-Pfad — Hedge gegen
+# keyserver.ubuntu.com-Downtime. Bei Maintainer-Key-Rotation neu bauen.
+RUN gpg --keyserver hkps://keyserver.ubuntu.com \
+        --recv-keys 18C7DF2819C1733D822D599EA500D6EE9CB0E540


### PR DESCRIPTION
## Summary

Zwei Container-seitige Vorbereitungen für HW3 §4.2 ("umgebungsabhängige Pfade robust behandeln" + GPG-Signatur-Verifikation):

**Fix 1 — BOOTLIN-Env-Var in SSH-Login-Shells sichtbar**

- Docker `ENV BOOTLIN_AARCH64_MUSL_PATH=…` propagiert nur an PID 1 (`docker exec`), nicht an sshd-Kinder — die Env-Var war in SSH-Sessions unsichtbar.
- HW3 §4.2 fordert "umgebungsabhängige Pfade robust behandeln" — `hw3.sh` soll `${BOOTLIN_AARCH64_MUSL_PATH:-/opt/cross/…}` als Env-Var-Override nutzen können; das braucht die Var aber in der Login-Shell.
- Fix: zusätzliche `RUN echo "…" >> /etc/environment` — PAM picked den Wert bei jedem SSH-Login auf; `docker exec` sieht weiterhin die bestehende ENV.

**Fix 2 — Buildroot-Maintainer-Key vorinstalliert** (neu)

- Buildroot-Tarballs sind GPG-signiert (Maintainer Thomas Petazzoni, Fingerprint `18C7DF2819C1733D822D599EA500D6EE9CB0E540`).
- GitHub-Actions-Runner starten als root in frisch provisioniertem Keyring → `gpg --verify` in `hw3.sh` scheitert ohne Key.
- Der `hw3.sh`-seitige `--recv-keys`-Fallback deckt das ab, hängt aber an `keyserver.ubuntu.com`, das mehrmals pro Jahr stundenweise ausfällt. In solchen Fenstern bricht dann jeder HW3-CI-Lauf aller Gruppen.
- Fix: `RUN gpg --recv-keys …` beim Image-Build. CI läuft danach autark gegen Keyserver-Downtime. Für pocketlab-SSH-User und Studis auf eigenem Laptop bleibt der `hw3.sh`-Fallback unverändert wirksam — der greift dort, wo der Key nicht im Home-Keyring ist.

## Verification (vor Fix, Container mit aktuellem Image)

```
$ ssh esyslab 'env | grep BOOTLIN'
(nichts)
$ ssh esyslab 'ls /opt/cross/'
aarch64--musl--stable-2024.02-1
```

Toolchain ist vorhanden, Env-Var fehlt. `hw3.sh` muss daher aktuell den Pfad hardcoden.

## Test plan

- [ ] Image neu bauen (`3_esys.yml`)
- [ ] Container starten, `ssh <user>@host 'env | grep BOOTLIN'` → zeigt `BOOTLIN_AARCH64_MUSL_PATH=/opt/cross/aarch64--musl--stable-2024.02-1`
- [ ] `docker exec <ctr> env | grep BOOTLIN` → weiterhin OK (bestehender ENV-Pfad bleibt)
- [ ] **Key-Präsenz im Root-Keyring:** `docker exec <ctr> gpg --list-keys 18C7DF2819C1733D822D599EA500D6EE9CB0E540` → Key wird ohne Keyserver-Roundtrip gefunden
- [ ] HW3 `hw3.sh` auf dem neuen Image: Build läuft durch, `--recv-keys`-Zweig wird im CI-Log NICHT aktiviert (No-op wegen vorinstalliertem Key)
- [ ] `hw3.sh`-Fallback-Pfad weiterhin verifizierbar: SSH als `pocketlab`, eigenen Keyring leer, `hw3.sh` ruft `--recv-keys` auf und läuft durch

## Nicht mergen

PR bleibt offen zur Abstimmung — kein Auto-Merge.