### PR TITLE
esyslab.yml: nur github-pages pusht nach :latest

### DIFF
--- a/.github/workflows/esyslab.yml
+++ b/.github/workflows/esyslab.yml
@@ -2,6 +2,14 @@ name: Build esyslab Docker Image
 
 on:
   push:
+    # Nur github-pages pusht nach ghcr.io/.../esyslab:latest. Ohne diesen
+    # Filter wuerden Pushes auf main den `:latest`-Tag ueberschreiben und
+    # je nach Stand der Branches ARM64-spezifische Pakete (qemu-system-arm)
+    # oder die Bootlin-aarch64-musl-Cross-Toolchain aus dem gepushten Image
+    # entfernen. `main` ist die kanonische Quelle, `github-pages` die
+    # Deployment-Linie mit Container-Runtime-Patches — nur letztere veroeffentlicht.
+    branches:
+      - github-pages
     paths:
       - '.github/workflows/esyslab.yml'
       - 'Dockerfile.esyslab'


### PR DESCRIPTION
## Summary

- Ohne Branch-Filter triggerte der esyslab-Workflow auf Pushes **jedes** Branches. Main und github-pages pushten beide denselben Tag `ghcr.io/.../esyslab:latest` — letzter Push gewann.
- Effekt: github-pages-Patches (Bootlin-aarch64-musl-Toolchain, `qemu-system-arm` auf ARM64-Hosts, C++ Cross-Compiler, Maintainer-Key-Preinstall) verschwanden aus dem veroeffentlichten `:latest`, sobald main zuletzt gepusht hatte (z.B. nach PR #90 "continue-on-error raus").
- Dieser PR zieht die Konvention aus `CLAUDE.md` sauber nach: **main = kanonische Quelle, github-pages = Deployment-Linie — nur letztere veroeffentlicht nach `:latest`**. Backports main → github-pages bleiben unveraendert moeglich, `workflow_dispatch` und die `workflow_run`-Chain aus dem base-image-Build sind nicht betroffen.

## Test plan

- [ ] Merge dieses PR triggert **keinen** neuen esyslab-Build (main matcht den Filter nicht).
- [ ] Folgender Push auf `github-pages` (z.B. naechster Dockerfile-Tweak) triggert den Build wie bisher und aktualisiert `:latest_ARM64`, `:latest_X64` und das Multi-Arch-Manifest `:latest`.
- [ ] `gh run list --workflow=esyslab.yml --limit 10` zeigt nach einer Weile nur noch Runs mit Head-Ref `github-pages`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)