### PR TITLE
Dockerfile.esyslab: Sync main ← github-pages + Branch-Rollen in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,3 +49,44 @@ ubuntu:22.04
 - All images expose port 22 (SSH), UI also exposes 5901 (VNC) and 40001 (noVNC)
 - Host port mapping: `-p 127.0.0.1:40405:22`
 - `dos2unix` is used throughout for cross-platform line ending compatibility
+
+## Branch-Rollen: `main` vs. `github-pages`
+
+Dieses Repo trägt zwei Branches mit komplementären, aber scharf getrennten
+Aufgaben. Der Unterschied ist nicht „stabil vs. experimentell", sondern
+**Quelle der Wahrheit vs. Deployment-Linie**.
+
+### `main` — Quelle der Wahrheit für Container-Code
+- Alle Änderungen an Dockerfiles, `config/**` und `.github/workflows/**`
+  landen ausschließlich hier (PR-basiert).
+- Triggert **keinen** Push nach `ghcr.io/.../esyslab:latest` — der
+  `esyslab.yml`-Workflow filtert `push`-Trigger auf `branches: [github-pages]`
+  (siehe PR #93). Das verhindert, dass Zwischenstände das gemeinsame
+  `:latest`-Manifest unter der Deployment-Linie wegdrücken.
+
+### `github-pages` — Deployment-Linie + Pages-Serving
+- GitHub Pages serviert `docs/**` von diesem Branch (Pages-Settings:
+  `source: {branch: github-pages, path: /docs}`, `build_type: legacy`,
+  Output: https://htwg-syslab.github.io/container/). Deshalb der Name.
+- Zusätzlich veröffentlicht der `esyslab.yml`-Workflow von hier (und nur
+  von hier) die Image-Tags `:latest_X64`, `:latest_ARM64` und das
+  Multi-Arch-Manifest `:latest`.
+- Dockerfile-Änderungen gehören **nicht** direkt auf diesen Branch.
+  Stattdessen: main → github-pages mergen, dann pushen. Der Merge-Push
+  triggert automatisch den Image-Build.
+- Der Parent-Workspace (`esys-workspace`) pinnt sein Submodul auf
+  genau diesen Branch, weil das Deployed-State Ihres Containers hier steht.
+
+### Doc-Änderungen in `docs/**`
+Direktes Commiten auf `github-pages` ist zulässig (Pages soll schnell
+aktualisiert werden). Wenn dieselbe Doku auch woanders gepflegt wird
+(GitBook-Space via `.gitbook.yaml` auf `main`), ist ein Rück-Merge nach
+main sinnvoll, aber nicht zwingend für den Deploy-Pfad.
+
+### Typischer Deploy-Flow nach einem Code-PR
+```bash
+# PR auf main gemerged (z.B. Dockerfile.esyslab-Update)
+git checkout github-pages && git pull
+git merge main              # bringt den neuen Dockerfile auf die Deploy-Linie
+git push origin github-pages  # triggert esyslab.yml → neues :latest
+```

--- a/Dockerfile.esyslab
+++ b/Dockerfile.esyslab
@@ -3,12 +3,12 @@ FROM ghcr.io/htwg-syslab/container/base:latest
 # Install ESYS Lab packages
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
-        build-essential make gcc clang cmake valgrind \
+        build-essential make gcc clang cmake valgrind time \
         libc6-dev gettext indent bats \
         netcat-openbsd net-tools iputils-ping traceroute bmon \
         lsof psmisc xz-utils unzip gnupg2 \
         uml-utilities strace kmod device-tree-compiler \
-        libssl-dev libelf-dev \
+        libssl-dev libelf-dev libcrypt-dev \
         flex bison \
         libncurses-dev libcurses-ocaml-dev zlib1g \
         lsb-release libnotify4 bc expect cpio rsync \
@@ -52,13 +52,16 @@ RUN dpkgArch="$(dpkg --print-architecture)"; \
     case "${dpkgArch##*-}" in \
         arm64) \
             packages="gcc-x86-64-linux-gnu \
+                      g++-x86-64-linux-gnu \
                       gdb-multiarch \
                       qemu-system-x86 \
+                      qemu-system-arm \
                       qemu-user-binfmt \
                       libc6-dev-amd64-cross" \
             ;; \
         amd64) \
             packages="gcc-aarch64-linux-gnu \
+                      g++-aarch64-linux-gnu \
                       gdb-multiarch \
                       qemu-system-x86 \
                       qemu-system-arm \
@@ -70,3 +73,38 @@ RUN dpkgArch="$(dpkg --print-architecture)"; \
             ;; \
     esac; \
     apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y $packages
+
+# --- Bootlin aarch64-musl Cross-Toolchain (HW3 External-Toolchain-Variante) ---
+# Erlaubt Buildroot, eigene Toolchain-Stages zu überspringen → CI-Build von
+# ~30-45 min auf ~5-10 min. Phase-0-Test (lab/solutions/hw3/external-toolchain-plan.md)
+# zeigt 4m54s im x86_64-Container. URL pinned auf Bootlin-Stable, sha256 verifiziert.
+# Nur auf amd64: Bootlin-Binaries sind x86_64-Host-→-aarch64-Target; auf arm64-Host
+# nicht ausführbar (außer über qemu-user) und wegen native-aarch64-gcc auch unnötig.
+ARG BOOTLIN_AARCH64_MUSL_VERSION=2024.02-1
+ARG BOOTLIN_AARCH64_MUSL_SHA256=aaa1a5c9212067de3618afbb8f3de4047d99fa1d23e5bc1452bab7fd3744df2e
+RUN dpkgArch="$(dpkg --print-architecture)"; \
+    if [ "$dpkgArch" = "amd64" ]; then \
+        cd /opt && \
+        wget -q "https://toolchains.bootlin.com/downloads/releases/toolchains/aarch64/tarballs/aarch64--musl--stable-${BOOTLIN_AARCH64_MUSL_VERSION}.tar.bz2" -O bootlin.tar.bz2 && \
+        echo "${BOOTLIN_AARCH64_MUSL_SHA256}  bootlin.tar.bz2" | sha256sum -c - && \
+        mkdir -p cross && \
+        tar xjf bootlin.tar.bz2 -C cross && \
+        rm bootlin.tar.bz2; \
+    else \
+        echo "Skipping Bootlin aarch64-musl toolchain on ${dpkgArch} (x86_64-host binaries, arm64 hat nativen aarch64-gcc)"; \
+    fi
+ENV BOOTLIN_AARCH64_MUSL_PATH=/opt/cross/aarch64--musl--stable-2024.02-1
+# SSH-Login-Shells lesen /etc/environment via PAM; Docker-ENV propagiert nur
+# an PID 1 (docker exec), nicht an sshd-Kinder. Damit HW3 §4.2 ("umgebungsabhängige
+# Pfade robust behandeln") die Env-Var nutzen kann, hier zusätzlich in /etc/environment.
+RUN echo "BOOTLIN_AARCH64_MUSL_PATH=/opt/cross/aarch64--musl--stable-${BOOTLIN_AARCH64_MUSL_VERSION}" >> /etc/environment
+
+# --- Buildroot-Maintainer-Key systemweit importieren (HW3 §1.1 / §4.2) ---
+# Buildroot-Tarballs sind GPG-signiert (Maintainer: Thomas Petazzoni). Bei
+# non-interaktivem Skript-Aufruf (CI-Runner, frisch provisionierter Container)
+# fehlt der Key im Root-Keyring — `gpg --verify` scheitert. Der hw3.sh-seitige
+# `--recv-keys`-Fallback deckt fremde Umgebungen (eigener Laptop, pocketlab-User)
+# ab; dieser Layer nimmt den Keyserver-Roundtrip aus dem CI-Pfad — Hedge gegen
+# keyserver.ubuntu.com-Downtime. Bei Maintainer-Key-Rotation neu bauen.
+RUN gpg --keyserver hkps://keyserver.ubuntu.com \
+        --recv-keys 18C7DF2819C1733D822D599EA500D6EE9CB0E540


### PR DESCRIPTION
## Summary

- Zieht `Dockerfile.esyslab` auf `main` byte-identisch auf den `origin/github-pages`-Stand nach. Mehrere HW3-relevante Patches (Bootlin-aarch64-musl-Toolchain, `qemu-system-arm` im arm64-Zweig, C++ Cross-Compiler in beiden Zweigen, Maintainer-Key-Preinstall, GNU `time`, `libcrypt-dev`) existierten bisher nur auf `github-pages`, weil dieser Branch bis PR #93 als einzige Quelle fuer `ghcr.io/.../esyslab:latest` diente.
- Ergaenzt `CLAUDE.md` um einen expliziten Abschnitt **„Branch-Rollen: `main` vs. `github-pages`"**. Faehrt die durch PR #93 etablierte Trennung schriftlich fest: `main` = Quelle der Wahrheit (kein `:latest`-Push), `github-pages` = Pages-Serving + Deploy-Linie. Dokumentiert den Flow `main → merge nach github-pages → Push triggert Build`.

## Keine Nebenwirkungen

- `main` triggert seit PR #93 keinen esyslab-Build mehr (`branches: [github-pages]`-Filter). Dieser PR aendert Dockerfile.esyslab auf `main` — **kein Image-Build, kein Push nach `:latest`**.
- Pages-Site https://htwg-syslab.github.io/container/ bleibt unveraendert (github-pages nicht angefasst).
- Parent-Submodul-Pin (`esys-workspace`) bleibt auf `github-pages`.
- Laufende Studi-PRs ziehen weiterhin das bereits deployte `:latest` — keine Aenderung sichtbar.

## Quelle der Dockerfile-Aenderung

`git checkout origin/github-pages -- Dockerfile.esyslab` — byte-identisch verifiziert:

```
$ git diff origin/github-pages -- Dockerfile.esyslab
(leer)
```

github-pages-Commits, die damit auf main ankommen:

| Commit | Inhalt |
|---|---|
| `b91a2d4` | Dockerfile.esyslab: qemu-system-arm fuer ARM64-Hosts |
| `390e2e1` | GNU time + Bootlin aarch64-musl Cross-Toolchain |
| `33a128c` | Bootlin-Toolchain nur auf amd64 + C++ Cross-Compiler |
| `84bafd7` | libcrypt-dev ergaenzt |
| `cfb1c87` | BOOTLIN_AARCH64_MUSL_PATH auch in /etc/environment |
| `0e6651a` | Buildroot-Maintainer-Key vorinstalliert |

`libcrypt-dev` ist auf `main` via PR #88 bereits weiter unten im Buildroot-host-side-dev-Header-Block vorhanden; github-pages hat es zusaetzlich in der oberen Paketliste. Die Redundanz ist harmlos (apt dedupliziert) und bleibt aus Gruenden der Byte-Identitaet erhalten.

## Test plan

- [ ] Merge triggert **keinen** esyslab-Build (main matcht PR #93-Filter nicht) — `gh run list --workflow=esyslab.yml --repo htwg-syslab/container --branch main --limit 5` danach unveraendert.
- [ ] Pages-Site bleibt auf `last-modified` vom letzten github-pages-Push stehen (kein ungewollter Pages-Rebuild).
- [ ] Naechster geplanter Deploy: `git checkout github-pages && git merge main && git push origin github-pages` — triggert regulaer den `esyslab.yml`-Build mit dem nachgezogenen Dockerfile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)