### PR TITLE
Dockerfile.esyslab: arm64-musl-Toolchain aus htwg-syslab/aarch64-musl-cross

### DIFF
--- a/Dockerfile.esyslab
+++ b/Dockerfile.esyslab
@@ -74,25 +74,42 @@ RUN dpkgArch="$(dpkg --print-architecture)"; \
     esac; \
     apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y $packages
 
-# --- Bootlin aarch64-musl Cross-Toolchain (HW3 External-Toolchain-Variante) ---
-# Erlaubt Buildroot, eigene Toolchain-Stages zu überspringen → CI-Build von
-# ~30-45 min auf ~5-10 min. Phase-0-Test (lab/solutions/hw3/external-toolchain-plan.md)
-# zeigt 4m54s im x86_64-Container. URL pinned auf Bootlin-Stable, sha256 verifiziert.
-# Nur auf amd64: Bootlin-Binaries sind x86_64-Host-→-aarch64-Target; auf arm64-Host
-# nicht ausführbar (außer über qemu-user) und wegen native-aarch64-gcc auch unnötig.
+# --- Externe aarch64-musl Cross-Toolchain (HW3 External-Toolchain-Variante) ---
+# Beide Archs bekommen eine externe musl-Cross-Toolchain unter /opt/cross/:
+#  * amd64: Bootlin-Tarball (x86_64-host → aarch64-target). Bootlin liefert nur
+#    x86_64-gehostete Toolchains.
+#  * arm64: htwg-syslab/aarch64-musl-cross-Release (aarch64-host → aarch64-target,
+#    selbst aus musl-cross-make gebaut, kompensiert die fehlende Bootlin-ARM64-
+#    Host-Variante; siehe https://github.com/htwg-syslab/aarch64-musl-cross).
+# Erlaubt Buildroot, eigene Toolchain-Stages zu überspringen → CI-Build
+# bleibt bei ~5-10 min statt 30-45 min auf beiden Archs. Beide pinned auf
+# konkrete Versionen, sha256-verifiziert.
 ARG BOOTLIN_AARCH64_MUSL_VERSION=2024.02-1
 ARG BOOTLIN_AARCH64_MUSL_SHA256=aaa1a5c9212067de3618afbb8f3de4047d99fa1d23e5bc1452bab7fd3744df2e
+ARG HTWG_AARCH64_MUSL_VERSION=2026.04-1
+ARG HTWG_AARCH64_MUSL_SHA256=e96f97f9ddb559b75c22986f7d46db4538aba27ce0c8fb97850ced2bf9b8d4c9
 RUN dpkgArch="$(dpkg --print-architecture)"; \
-    if [ "$dpkgArch" = "amd64" ]; then \
-        cd /opt && \
-        wget -q "https://toolchains.bootlin.com/downloads/releases/toolchains/aarch64/tarballs/aarch64--musl--stable-${BOOTLIN_AARCH64_MUSL_VERSION}.tar.bz2" -O bootlin.tar.bz2 && \
-        echo "${BOOTLIN_AARCH64_MUSL_SHA256}  bootlin.tar.bz2" | sha256sum -c - && \
-        mkdir -p cross && \
-        tar xjf bootlin.tar.bz2 -C cross && \
-        rm bootlin.tar.bz2; \
-    else \
-        echo "Skipping Bootlin aarch64-musl toolchain on ${dpkgArch} (x86_64-host binaries, arm64 hat nativen aarch64-gcc)"; \
-    fi
+    case "$dpkgArch" in \
+        amd64) \
+            cd /opt && \
+            wget -q "https://toolchains.bootlin.com/downloads/releases/toolchains/aarch64/tarballs/aarch64--musl--stable-${BOOTLIN_AARCH64_MUSL_VERSION}.tar.bz2" -O bootlin.tar.bz2 && \
+            echo "${BOOTLIN_AARCH64_MUSL_SHA256}  bootlin.tar.bz2" | sha256sum -c - && \
+            mkdir -p cross && \
+            tar xjf bootlin.tar.bz2 -C cross && \
+            rm bootlin.tar.bz2 \
+            ;; \
+        arm64) \
+            cd /opt && \
+            wget -q "https://github.com/htwg-syslab/aarch64-musl-cross/releases/download/v${HTWG_AARCH64_MUSL_VERSION}/aarch64--musl--stable-${HTWG_AARCH64_MUSL_VERSION}.tar.xz" -O htwg.tar.xz && \
+            echo "${HTWG_AARCH64_MUSL_SHA256}  htwg.tar.xz" | sha256sum -c - && \
+            mkdir -p cross && \
+            tar xJf htwg.tar.xz -C cross && \
+            rm htwg.tar.xz \
+            ;; \
+        *) \
+            echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 \
+            ;; \
+    esac
 ENV BOOTLIN_AARCH64_MUSL_PATH=/opt/cross/aarch64--musl--stable-2024.02-1
 # SSH-Login-Shells lesen /etc/environment via PAM; Docker-ENV propagiert nur
 # an PID 1 (docker exec), nicht an sshd-Kinder. Damit HW3 §4.2 ("umgebungsabhängige


### PR DESCRIPTION
## Summary

Bisheriger Stand: Auf arm64-Hosts wurde der Bootlin-Toolchain-Install-Schritt uebersprungen, weil Bootlin nur x86_64-gehostete aarch64-musl-Toolchains anbietet. Das esyslab-arm64-Image hatte daher **keine** externe musl-Toolchain unter `/opt/cross/` — Studi-HW3 auf ARM64-Hosts konnte die Bootlin-Variante der Musterloesung nicht ausfuehren, was dem didaktischen Prinzip „HW3 immer mit externer musl-Toolchain" widerspricht.

Dieser PR zieht das Release-Asset eines neuen Repos [`htwg-syslab/aarch64-musl-cross`](https://github.com/htwg-syslab/aarch64-musl-cross) (v2026.04-1) fuer den arm64-Zweig ein. Das Repo baut die Toolchain selbst via `musl-cross-make` auf `ubuntu-24.04-arm` — einmal pro Tag-Release, reproduzierbar, sha256-verifiziert.

## Version-Matching

| Komponente | Bootlin 2024.02-1 (amd64) | htwg-syslab v2026.04-1 (arm64) |
|---|---|---|
| GCC | 12.3.0 | **12.4.0** (Patch-Level-Diff, ABI-kompatibel) |
| musl | 1.2.5 | **1.2.5** (identisch) |
| Binutils | 2.41 | **2.44** (neuer, ABI-kompatibel) |
| Kernel-Headers | 4.19.255 | 4.19.88 (beide `_HEADERS_4_19=y` in Buildroot) |
| Target-Triple | `aarch64-buildroot-linux-musl-` | `aarch64-linux-musl-` |

Das Target-Triple ist der einzige semantische Unterschied — die Studi-hw3.sh-Musterloesung switcht zwischen beiden Prefixen via `dpkg --print-architecture`.

## Dockerfile-Aenderungen

- `if/else` → `case "$dpkgArch"` (drei Branches: amd64, arm64, unsupported).
- Zwei neue `ARG` fuer `HTWG_AARCH64_MUSL_VERSION` + `_SHA256`.
- Arm64-Case: `wget` + `sha256sum -c` + `tar xJf` analog zum bestehenden Bootlin-Muster.
- `ENV BOOTLIN_AARCH64_MUSL_PATH=...` bleibt unveraendert (amd64-Pfad). Die Studi-hw3.sh setzt den arm64-Pfad in ihrer arch-switch-Logik selbst; kein API-Break.

## Effekte

- **Image-Groesse arm64**: +~293 MB xz-komprimiert, ~400 MB entpackt. Einmalig pro Image-Build.
- **CI-Laufzeit**: +~10-20 s fuer wget+extract bei jedem Image-Rebuild (gecacht nach erstem Build). Kein Source-Compile.
- **amd64**: **unveraendert** — Bootlin-Pfad und Env-Variable identisch zu vorher.

## Test plan

- [ ] PR-Merge triggert kein Image-Build (main hat PR #93-branches-Filter auf `github-pages`).
- [ ] Nach Merge: `main → github-pages` mergen + pushen — esyslab-Workflow baut beide Arch-Images und pusht `:latest_X64` + `:latest_ARM64` + Multi-Arch-Manifest.
- [ ] arm64-Image-Verifikation: `docker run --rm --platform linux/arm64 ghcr.io/htwg-syslab/container/esyslab:latest ls /opt/cross/aarch64--musl--stable-2026.04-1/bin/aarch64-linux-musl-gcc` gibt den Binary aus.
- [ ] amd64-Image-Verifikation: Pfad `/opt/cross/aarch64--musl--stable-2024.02-1/bin/aarch64-buildroot-linux-musl-gcc` unveraendert vorhanden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)