### PR TITLE
Add aria-pressed to theme toggle (a11y)

### DIFF
--- a/docs/_includes/footer_custom.html
+++ b/docs/_includes/footer_custom.html
@@ -5,16 +5,19 @@
       jtd.setTheme(saved);
     }
 
+    var currentTheme = jtd.getTheme();
     var btn = document.createElement('button');
     btn.className = 'theme-toggle';
     btn.setAttribute('aria-label', 'Toggle light/dark mode');
-    btn.textContent = jtd.getTheme() === 'dark' ? '\u2600\uFE0F' : '\uD83C\uDF19';
+    btn.setAttribute('aria-pressed', currentTheme === 'dark' ? 'true' : 'false');
+    btn.textContent = currentTheme === 'dark' ? '\u2600\uFE0F' : '\uD83C\uDF19';
 
     btn.addEventListener('click', function() {
       var next = jtd.getTheme() === 'dark' ? 'light' : 'dark';
       jtd.setTheme(next);
       localStorage.setItem('jtd-theme', next);
       btn.textContent = next === 'dark' ? '\u2600\uFE0F' : '\uD83C\uDF19';
+      btn.setAttribute('aria-pressed', next === 'dark' ? 'true' : 'false');
     });
 
     document.body.appendChild(btn);


### PR DESCRIPTION
## Summary
- Cherry-pick aus stillgelegtem `migrate-docs-to-main`-Branch (Commit `15ff943` vom März 2026).
- `docs/_includes/footer_custom.html`: `aria-pressed`-Attribut am Theme-Toggle für Screen-Reader.

## Test plan
- [ ] Pages-Build grün
- [ ] Toggle-Button im Live-Site lädt mit aria-pressed=false und togglet zu true bei Klick