### PR TITLE
esyslab: ccache hinzufügen (Buildroot BR2_CCACHE für eigene Runner)

### DIFF
--- a/Dockerfile.esyslab
+++ b/Dockerfile.esyslab
@@ -3,7 +3,7 @@ FROM ghcr.io/htwg-syslab/container/base:latest
 # Install ESYS Lab packages
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
-        build-essential make gcc clang cmake valgrind time \
+        build-essential make gcc clang cmake valgrind time ccache \
         libc6-dev gettext indent bats \
         netcat-openbsd net-tools iputils-ping traceroute bmon \
         lsof psmisc xz-utils unzip gnupg2 \


### PR DESCRIPTION
## Summary
- Eine Zeile in `Dockerfile.esyslab`: `ccache` in die `apt-get install`-Liste der ESYS-Lab-Packages
- Voraussetzung für ccache-basierten Speedup der HW3/HW4-CI auf den self-hosted `esys-amd64`-Runnern

## Hintergrund
Die HW3/HW4-Workflows werden auf eigene Runner umgestellt (siehe `classroom-template` #57, läuft). Nächster Speedup-Hebel: `BR2_CCACHE=y` in der Buildroot-Konfig + Host-Volume `/srv/esys-cache/ccache` als ccache-Backing-Store. Ohne `ccache`-Binary im Container-Image scheitert der Build mit *"The 'ccache' program was not found"*.

Erwarteter Gewinn nach Aktivierung: -5 bis -8 min pro warmem CI-Build (Linux-Kernel + busybox + Userspace-Pakete sind zwischen Gruppen quasi identisch → hohe Cache-Hit-Rate).

## Test plan
- [ ] Image-Build `esyslab.yml` läuft grün
- [ ] `:latest` enthält `ccache` (`docker run --rm ghcr.io/htwg-syslab/container/esyslab:latest ccache --version`)
- [ ] Folge-Edit in `htwg-syslab-esys/esys-ss26-grp0` (Branch `hw4-m4-minimal`) aktiviert `BR2_CCACHE=y` und mountet `/ccache`, CI-Lauf vergleicht Wallclock